### PR TITLE
fix Hindley-Milner example

### DIFF
--- a/019_hindley_milner/src/lib/parser.mbt
+++ b/019_hindley_milner/src/lib/parser.mbt
@@ -41,15 +41,7 @@ fn next_char(self : Tokenizer) -> Char? {
 }
 
 fn lexeme(self : Tokenizer) -> String {
-  let len = self.cursor - self.token_start
-  if len <= 0 {
-    return ""
-  }
-  let b = Bytes::make(len, b'\x00')
-  for i = 0; i < len; i = i + 1 {
-    b[i] = self.src[self.token_start + i].to_int().to_byte()
-  }
-  b.to_string()
+  self.src.substring(start=self.token_start, end=self.cursor)
 }
 
 fn peek(self : Tokenizer) -> Token!TokenError {
@@ -70,7 +62,7 @@ type! TokenError {
   InvalidCharacterError(String)
   UnexpectedEofError
   UnexpectedTokenError(String)
-}
+} derive(Show)
 
 fn do_next(self : Tokenizer) -> Token!TokenError {
   self.token_start = self.cursor

--- a/019_hindley_milner/src/lib/typecheck.mbt
+++ b/019_hindley_milner/src/lib/typecheck.mbt
@@ -73,7 +73,7 @@ fn unify(t1 : Type, t2 : Type) -> Unit!TypeCheckError {
     (T_Var({ val: Free(tag, lvl) } as tv), ty)
     | (ty, T_Var({ val: Free(tag, lvl) } as tv)) => {
       match ty {
-        T_Var({ val: Free(alt_tag, _) }) => if tag == alt_tag {  }
+        T_Var({ val: Free(alt_tag, _) }) => if tag == alt_tag { return }
         _ => ()
       }
       ty.check_occurs!(tag, lvl)


### PR DESCRIPTION
The Hindley-Milner example is broken (it typechecks, but the runtime result is incorrect). Some bugs are introduced while adapting the example to recent language change. This PR fixes the example.