### PR TITLE
Update 003_basic_constants.mbt

### DIFF
--- a/003_basic_constants.mbt
+++ b/003_basic_constants.mbt
@@ -16,10 +16,10 @@ fn main {
   println(num4)
 
   // Double precision floating point  
-  let num5 : Double = 3.14 
+  let _num5 : Double = 3.14 
   
   // Unsigned integer with 32 bits and 64 bits
-  let unsigned32 : UInt = 1000
-  let unsigned64 : UInt64 = 1000
+  let _unsigned32 : UInt = 1000
+  let _unsigned64 : UInt64 = 1000
 }
 


### PR DESCRIPTION
The warning occurred because the variables (num5, unsigned32, unsigned64) were declared but not used in the code, which led to the unused variable warning. By either printing the variables or using underscores (_) to suppress the warnings, the unused variable issue was resolved, and the warning was eliminated.